### PR TITLE
feat: add SCX.ai provider

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -106,6 +106,7 @@ export const LATITUDE: string = 'latitude';
 export const DATABRICKS: string = 'databricks';
 export const REQUESTY: string = 'requesty';
 export const PINECONE: string = 'pinecone';
+export const SCX_AI: string = 'scx-ai';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -174,6 +175,7 @@ export const VALID_PROVIDERS = [
   DATABRICKS,
   REQUESTY,
   PINECONE,
+  SCX_AI,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -54,6 +54,7 @@ import OVHcloudConfig from './ovhcloud';
 import PalmAIConfig from './palm';
 import PerplexityAIConfig from './perplexity-ai';
 import PineconeConfig from './pinecone';
+import SCXAIConfig from './scx-ai';
 import PredibaseConfig from './predibase';
 import QdrantConfig from './qdrant';
 import RecraftAIConfig from './recraft-ai';
@@ -153,6 +154,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   latitude: LatitudeConfig,
   databricks: DatabricksConfig,
   pinecone: PineconeConfig,
+  'scx-ai': SCXAIConfig,
 };
 
 export default Providers;

--- a/src/providers/scx-ai/api.ts
+++ b/src/providers/scx-ai/api.ts
@@ -1,0 +1,18 @@
+import { ProviderAPIConfig } from '../types';
+
+const SCXAIAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) => providerOptions.customHost || 'https://api.scx.ai/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default SCXAIAPIConfig;

--- a/src/providers/scx-ai/index.ts
+++ b/src/providers/scx-ai/index.ts
@@ -1,0 +1,18 @@
+import { SCX_AI } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import SCXAIAPIConfig from './api';
+
+// SCX.ai exposes /v1/completions, but it is aliased to chat: the response is a
+// `chat.completion` carrying `message` rather than a `text_completion` carrying
+// `text`. Text completions are left out so the shared transformer is not handed
+// a shape it cannot read.
+const SCXAIConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams(['logprobs', 'top_logprobs', 'n', 'logit_bias']),
+  api: SCXAIAPIConfig,
+  responseTransforms: responseTransformers(SCX_AI, {
+    chatComplete: true,
+  }),
+};
+
+export default SCXAIConfig;


### PR DESCRIPTION
Adds **SCX.ai** as a provider. SCX.ai is an Australian AI platform serving models over an OpenAI-compatible API at `https://api.scx.ai/v1`.

### Implementation

Bearer auth over an OpenAI-compatible surface, so the provider reuses `chatCompleteParams` and `responseTransformers` from `open-ai-base` with no custom transforms:

- `src/providers/scx-ai/api.ts` — base URL, auth header, `/chat/completions`. `customHost` is honoured for SCX's self-hosted container deployments.
- `src/providers/scx-ai/index.ts` — params + response transforms
- `src/globals.ts` — `SCX_AI` constant, added to `VALID_PROVIDERS`
- `src/providers/index.ts` — registered in the `Providers` map

Streaming needs no special handling: SCX emits standard SSE with a trailing usage-only chunk and a `\n\n` delimiter, so the default split pattern applies (verified against the raw byte stream).

### Text completions are deliberately excluded

SCX publishes `/v1/completions`, but it is aliased to chat — the response is a `chat.completion` carrying `message` rather than a `text_completion` carrying `text`:

```
$ curl .../v1/completions -d '{"model":"GLM-5.2","prompt":"The capital of France is","max_tokens":10}'
{"object":"chat.completion", "choices":[{"message":{"role":"assistant", ...}}]}
```

Wiring `complete` would hand the shared transformer a shape it cannot read, so only `chatComplete` is declared. There is a comment in `index.ts` recording this so it does not look like an oversight.

### Excluded params

`logprobs`, `top_logprobs`, `n` and `logit_bias` — the ones SCX documents as ignored and omits from each model's `supported_sampling_parameters` in `/v1/models`.

`seed`, `presence_penalty` and `frequency_penalty` are deliberately **kept**: SCX lists them as supported, and `seed` was verified to produce deterministic output (identical seeds returned byte-identical completions, different seeds diverged).

### Verification

`pnpm format`, `pnpm lint` and `pnpm build` all clean. `pnpm test` → **691 passed, 33 skipped**, unchanged from `main`.

Ran the gateway locally and routed live traffic through it against `GLM-5.2`:

- chat completion → `provider: "scx-ai"`, correct usage accounting
- tool calling → one `tool_calls` entry, `finish_reason: "tool_calls"`
- streaming → 11 chunks, `[DONE]` terminator, usage chunk present

Happy to add an integration test alongside the other providers if you would like one — I did not want to presume the credential-handling convention for a provider you do not yet have a key for.
