### PR TITLE
feat: add SaladCloud provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ CEREBRAS_API_KEY=
 # SambaNova
 SAMBANOVA_API_KEY=
 
+# SaladCloud AI Gateway
+SALAD_CLOUD_API_KEY=
+
 # xAI
 XAI_API_KEY=
 

--- a/src/__tests__/provider-ping.test.ts
+++ b/src/__tests__/provider-ping.test.ts
@@ -93,6 +93,12 @@ const PROVIDERS: ProviderEntry[] = [
     env: { SAMBANOVA_API_KEY: '' },
   },
   {
+    provider: 'saladcloud',
+    model: 'qwen3.6-35b-a3b',
+    responsesModel: 'qwen3.6-35b-a3b',
+    env: { SALAD_CLOUD_API_KEY: '' },
+  },
+  {
     provider: 'x-ai',
     model: 'grok-3-mini-fast',
     env: { XAI_API_KEY: '' },

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -77,6 +77,7 @@ export const SILICONFLOW: string = 'siliconflow';
 export const CEREBRAS: string = 'cerebras';
 export const INFERENCENET: string = 'inference-net';
 export const SAMBANOVA: string = 'sambanova';
+export const SALADCLOUD: string = 'saladcloud';
 export const LEMONFOX_AI: string = 'lemonfox-ai';
 export const UPSTAGE: string = 'upstage';
 export const LAMBDA: string = 'lambda';
@@ -150,6 +151,7 @@ export const VALID_PROVIDERS = [
   CEREBRAS,
   INFERENCENET,
   SAMBANOVA,
+  SALADCLOUD,
   LEMONFOX_AI,
   UPSTAGE,
   LAMBDA,

--- a/src/providers/__tests__/saladcloud.test.ts
+++ b/src/providers/__tests__/saladcloud.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { SALADCLOUD, VALID_PROVIDERS } from '../../globals';
+import { transformUsingProviderConfig } from '../../services/transformToProviderRequest';
+import type { Options, Params } from '../../types/requestBody';
+import ProviderConfigs from '../index';
+import type { ChatCompletionResponse, ErrorResponse, ProviderConfig } from '../types';
+
+const saladcloud = (ProviderConfigs as any).saladcloud;
+
+const complete = (response: Record<string, unknown>, status = 200, strict = true) =>
+  saladcloud.responseTransforms.chatComplete(response, status, new Headers(), strict);
+
+describe('saladcloud is reachable', () => {
+  it('is registered and allowed as a provider', () => {
+    expect(saladcloud).toBeDefined();
+    expect(VALID_PROVIDERS).toContain(SALADCLOUD);
+  });
+
+  it('uses the SaladCloud chat completions endpoint and bearer authentication', () => {
+    const providerOptions = { apiKey: 'test-key' } as Options;
+
+    expect(saladcloud.api.getBaseURL({ providerOptions })).toBe('https://ai.salad.cloud/v1');
+    expect(saladcloud.api.getEndpoint({ fn: 'chatComplete', providerOptions })).toBe(
+      '/chat/completions',
+    );
+    expect(saladcloud.api.headers({ providerOptions })).toEqual({
+      Authorization: 'Bearer test-key',
+    });
+  });
+
+  it('passes streamed OpenAI-compatible chunks through unchanged', () => {
+    expect(saladcloud.responseTransforms['stream-chatComplete']).toBeUndefined();
+  });
+});
+
+describe('what saladcloud is sent', () => {
+  it('defaults only to the requested 35B model', () => {
+    const request = transformUsingProviderConfig(
+      saladcloud.chatComplete as ProviderConfig,
+      { messages: [{ role: 'user', content: 'hi' }] } as Params,
+    );
+
+    expect(request.model).toBe('qwen3.6-35b-a3b');
+  });
+
+  it('keeps supported OpenAI and SaladCloud parameters', () => {
+    const request = transformUsingProviderConfig(
+      saladcloud.chatComplete as ProviderConfig,
+      {
+        model: 'qwen3.6-35b-a3b',
+        messages: [{ role: 'user', content: 'hi' }],
+        reasoning_effort: 'medium',
+        top_k: 40,
+        chat_template_kwargs: { enable_thinking: false },
+        tools: [{ type: 'function', function: { name: 'answer' } }],
+        response_format: { type: 'json_object' },
+      } as Params,
+    );
+
+    expect(request).toMatchObject({
+      model: 'qwen3.6-35b-a3b',
+      reasoning_effort: 'medium',
+      top_k: 40,
+      chat_template_kwargs: { enable_thinking: false },
+      response_format: { type: 'json_object' },
+    });
+    expect(request.tools).toHaveLength(1);
+  });
+
+  it('drops OpenAI-only parameters the SaladCloud endpoint does not accept', () => {
+    const request = transformUsingProviderConfig(
+      saladcloud.chatComplete as ProviderConfig,
+      {
+        model: 'qwen3.6-35b-a3b',
+        messages: [{ role: 'user', content: 'hi' }],
+        service_tier: 'auto',
+        store: true,
+        verbosity: 'high',
+      } as Params,
+    );
+
+    expect(request).not.toHaveProperty('service_tier');
+    expect(request).not.toHaveProperty('store');
+    expect(request).not.toHaveProperty('verbosity');
+  });
+});
+
+describe('what saladcloud answers with', () => {
+  const reply = (message: Record<string, unknown>) => ({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    created: 1_735_891_200,
+    model: 'qwen3.6-35b-a3b',
+    choices: [{ index: 0, message, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 4, total_tokens: 5 },
+  });
+
+  it('preserves reasoning and exposes it to the Responses adapter', () => {
+    const result = complete(
+      reply({ role: 'assistant', reasoning_text: 'Think briefly.', content: 'Hello.' }),
+      200,
+      false,
+    ) as ChatCompletionResponse;
+
+    expect(result.provider).toBe(SALADCLOUD);
+    expect((result.choices[0].message as any).reasoning_content).toBe('Think briefly.');
+    expect((result.choices[0].message as any).content_blocks).toContainEqual({
+      type: 'thinking',
+      thinking: 'Think briefly.',
+    });
+  });
+
+  it('normalizes SaladCloud problem details', () => {
+    const result = complete(
+      { status: 503, title: 'Service Unavailable', type: 'about:blank' },
+      503,
+    ) as ErrorResponse;
+
+    expect(result.provider).toBe(SALADCLOUD);
+    expect(result.error.message).toContain('Service Unavailable');
+    expect(result.error.code).toBe('503');
+  });
+});

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -61,6 +61,7 @@ import RekaAIConfig from './reka-ai';
 import ReplicateConfig from './replicate';
 import RequestyConfig from './requesty';
 import SagemakerConfig from './sagemaker';
+import SaladCloudConfig from './saladcloud';
 import SambaNovaConfig from './sambanova';
 import SegmindConfig from './segmind';
 import SiliconFlowConfig from './siliconflow';
@@ -126,6 +127,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'x-ai': XAIConfig,
   qdrant: QdrantConfig,
   sagemaker: SagemakerConfig,
+  saladcloud: SaladCloudConfig,
   nebius: NebiusConfig,
   'recraft-ai': RecraftAIConfig,
   milvus: MilvusConfig,

--- a/src/providers/saladcloud/api.ts
+++ b/src/providers/saladcloud/api.ts
@@ -1,0 +1,18 @@
+import { ProviderAPIConfig } from '../types';
+
+const SaladCloudAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://ai.salad.cloud/v1',
+  headers: ({ providerOptions }) => ({
+    Authorization: `Bearer ${providerOptions.apiKey}`,
+  }),
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default SaladCloudAPIConfig;

--- a/src/providers/saladcloud/chatComplete.ts
+++ b/src/providers/saladcloud/chatComplete.ts
@@ -1,0 +1,99 @@
+import { SALADCLOUD } from '../../globals';
+import { OpenAIErrorResponseTransform } from '../openai/utils';
+import { ChatCompletionResponse, ErrorResponse, ProviderConfig } from '../types';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+  transformReasoning,
+} from '../utils';
+
+export const SaladCloudChatCompleteExcludedParams = [
+  'audio',
+  'logit_bias',
+  'logprobs',
+  'metadata',
+  'modalities',
+  'parallel_tool_calls',
+  'prediction',
+  'prompt_cache_key',
+  'prompt_cache_retention',
+  'safety_identifier',
+  'service_tier',
+  'store',
+  'top_logprobs',
+  'verbosity',
+  'web_search_options',
+];
+
+export const SaladCloudChatCompleteDefaults = {
+  model: 'qwen3.6-35b-a3b',
+};
+
+export const SaladCloudChatCompleteExtraParams: ProviderConfig = {
+  top_k: {
+    param: 'top_k',
+  },
+  chat_template_kwargs: {
+    param: 'chat_template_kwargs',
+  },
+};
+
+interface SaladCloudProblemDetails {
+  detail?: string;
+  status?: number;
+  title?: string;
+  type?: string;
+}
+
+export const SaladCloudChatCompleteResponseTransform = (
+  response: ChatCompletionResponse | ErrorResponse | SaladCloudProblemDetails,
+  responseStatus: number,
+  _responseHeaders: Headers,
+  strictOpenAiCompliance: boolean,
+): ChatCompletionResponse | ErrorResponse => {
+  if (responseStatus !== 200) {
+    if ('error' in response) {
+      return OpenAIErrorResponseTransform(response, SALADCLOUD);
+    }
+
+    const problem = response as SaladCloudProblemDetails;
+    return generateErrorResponse(
+      {
+        message: problem.detail ?? problem.title ?? `HTTP ${responseStatus}`,
+        type: problem.type ?? null,
+        param: null,
+        code: problem.status === undefined ? null : String(problem.status),
+      },
+      SALADCLOUD,
+    );
+  }
+
+  const answered = response as ChatCompletionResponse;
+  if (!Array.isArray(answered.choices)) {
+    return generateInvalidProviderResponseError(response as Record<string, unknown>, SALADCLOUD);
+  }
+
+  return {
+    ...answered,
+    provider: SALADCLOUD,
+    choices: answered.choices.map((choice) => {
+      const message = choice.message as typeof choice.message & {
+        reasoning?: string;
+        reasoning_content?: string;
+        reasoning_text?: string;
+      };
+      const reasoning = message.reasoning_content || message.reasoning || message.reasoning_text;
+
+      return {
+        ...choice,
+        message: {
+          ...message,
+          ...transformReasoning(
+            { ...message, reasoning_content: reasoning },
+            strictOpenAiCompliance,
+          ),
+        },
+      };
+    }),
+  };
+};

--- a/src/providers/saladcloud/index.ts
+++ b/src/providers/saladcloud/index.ts
@@ -1,0 +1,23 @@
+import { chatCompleteParams } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import SaladCloudAPIConfig from './api';
+import {
+  SaladCloudChatCompleteDefaults,
+  SaladCloudChatCompleteExcludedParams,
+  SaladCloudChatCompleteExtraParams,
+  SaladCloudChatCompleteResponseTransform,
+} from './chatComplete';
+
+const SaladCloudConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams(
+    SaladCloudChatCompleteExcludedParams,
+    SaladCloudChatCompleteDefaults,
+    SaladCloudChatCompleteExtraParams,
+  ),
+  api: SaladCloudAPIConfig,
+  responseTransforms: {
+    chatComplete: SaladCloudChatCompleteResponseTransform,
+  },
+};
+
+export default SaladCloudConfig;


### PR DESCRIPTION
## Summary

- register SaladCloud AI Gateway as a Lightport provider
- route OpenAI-compatible chat-completions requests to `https://ai.salad.cloud/v1`
- name only `qwen3.6-35b-a3b` as the provider default and integration-test model
- preserve SaladCloud reasoning in chat responses and expose it to Lightport's Responses adapter
- support SaladCloud's `top_k`, `reasoning_effort`, and `chat_template_kwargs` request parameters
- normalize both OpenAI-style errors and SaladCloud problem-detail responses

## Usage

Send requests with `x-lightport-provider: saladcloud` and a Salad API key as the bearer token. If no model is supplied, Lightport uses `qwen3.6-35b-a3b`.

Reasoning remains enabled by the provider by default. Callers can forward `reasoning_effort`, or explicitly disable Qwen thinking with `chat_template_kwargs: { "enable_thinking": false }`.

## Validation

- `vitest run` — 699 tests passed, 35 skipped
- `oxlint src/`
- `tsdown`
- `knip`
- `oxfmt --check` on all changed files
- `git diff --check`

The live provider smoke tests skip when `SALAD_CLOUD_API_KEY` is not configured.

## References

- https://docs.salad.com/ai-gateway/tutorials/getting-started
- https://docs.salad.com/ai-gateway/reference/models
- https://github.com/SaladTechnologies/ai-sdk-provider
