### PR TITLE
feat: add EmpirioLabs AI provider

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -67,6 +67,7 @@ export const LINGYI: string = 'lingyi';
 export const ZHIPU: string = 'zhipu';
 export const NOVITA_AI: string = 'novita-ai';
 export const MONSTERAPI: string = 'monsterapi';
+export const EMPIRIOLABS: string = 'empiriolabs';
 export const DEEPSEEK: string = 'deepseek';
 export const PREDIBASE: string = 'predibase';
 export const TRITON: string = 'triton';
@@ -139,6 +140,7 @@ export const VALID_PROVIDERS = [
   NOVITA_AI,
   MONSTERAPI,
   DEEPSEEK,
+  EMPIRIOLABS,
   PREDIBASE,
   TRITON,
   VOYAGE,

--- a/src/providers/empiriolabs/api.ts
+++ b/src/providers/empiriolabs/api.ts
@@ -1,0 +1,21 @@
+import { ProviderAPIConfig } from '../types';
+
+const EmpirioLabsAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) =>
+    providerOptions.customHost || 'https://api.empiriolabs.ai/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      case 'embed':
+        return '/embeddings';
+      default:
+        return '';
+    }
+  },
+};
+
+export default EmpirioLabsAPIConfig;

--- a/src/providers/empiriolabs/index.ts
+++ b/src/providers/empiriolabs/index.ts
@@ -1,0 +1,17 @@
+import { EMPIRIOLABS } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { OpenAIEmbedConfig } from '../openai/embed';
+import { ProviderConfigs } from '../types';
+import EmpirioLabsAPIConfig from './api';
+
+const EmpirioLabsConfig: ProviderConfigs = {
+  api: EmpirioLabsAPIConfig,
+  chatComplete: chatCompleteParams([]),
+  embed: OpenAIEmbedConfig,
+  responseTransforms: responseTransformers(EMPIRIOLABS, {
+    chatComplete: true,
+    embed: true,
+  }),
+};
+
+export default EmpirioLabsConfig;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,6 +16,7 @@ import DatabricksConfig from './databricks';
 import DeepbricksConfig from './deepbricks';
 import DeepInfraConfig from './deepinfra';
 import DeepSeekAPIConfig from './deepseek';
+import EmpirioLabsConfig from './empiriolabs';
 import { FeatherlessAIConfig } from './featherless-ai';
 import FireworksAIConfig from './fireworks-ai';
 import GoogleConfig from './google';
@@ -109,6 +110,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'novita-ai': NovitaAIConfig,
   monsterapi: MonsterAPIConfig,
   deepseek: DeepSeekAPIConfig,
+  empiriolabs: EmpirioLabsConfig,
   predibase: PredibaseConfig,
   triton: TritonConfig,
   voyage: VoyageConfig,


### PR DESCRIPTION
Adds EmpirioLabs AI as an OpenAI-compatible provider (`empiriolabs`).

- Base URL `https://api.empiriolabs.ai/v1`
- Chat completions and embeddings via the shared OpenAI helpers
- Bearer auth (`EMPIRIOLABS_API_KEY` / `Authorization`)

This is a refile of [Portkey-AI/gateway#1690](https://github.com/Portkey-AI/gateway/pull/1690) onto Lightport, after the note that Lightport is the maintained fork.

Docs: https://docs.empiriolabs.ai
Catalog: https://empiriolabs.ai/models