### PR TITLE
fix: apply requestTimeout to custom request handlers

### DIFF
--- a/src/__tests__/customHandlerTimeout.test.ts
+++ b/src/__tests__/customHandlerTimeout.test.ts
@@ -1,0 +1,81 @@
+import createApp from '../index';
+import Providers from '../providers';
+import { externalServiceFetch } from '../utils/fetch';
+import getPort from 'get-port';
+import http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const apps: Array<ReturnType<typeof createApp>> = [];
+const servers: http.Server[] = [];
+const restores: Array<() => void> = [];
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()));
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+  restores.splice(0).forEach((restore) => restore());
+});
+
+/**
+ * Gives a provider a custom request handler for chatComplete, the way bedrock
+ * carries one for its file and batch endpoints. The handler reaches the
+ * provider through externalServiceFetch, so it inherits whatever ambient abort
+ * signal the gateway has wired up - which is the whole question here: a
+ * requestTimeout has to reach it, or a call to a wedged provider hangs forever.
+ */
+const withCustomChatHandler = (provider: string, customHost: string) => {
+  const config = (Providers as Record<string, any>)[provider];
+  const previous = config.requestHandlers;
+  config.requestHandlers = {
+    ...previous,
+    chatComplete: async () => {
+      // No try/catch: an abort surfaces as an AbortError the gateway is meant
+      // to map to a timeout, exactly as the non-handler path does.
+      return externalServiceFetch(`${customHost}/chat`, { method: 'POST' });
+    },
+  };
+  restores.push(() => {
+    config.requestHandlers = previous;
+  });
+};
+
+describe('custom request handler timeout', () => {
+  it('bounds a custom request handler by requestTimeout', async () => {
+    // A provider that accepts the connection and then never answers, the shape
+    // a file or batch call to a wedged backend takes.
+    const silent = http.createServer(() => {
+      // Never responds.
+    });
+    servers.push(silent);
+    const silentPort = await getPort();
+    await new Promise<void>((resolve) => silent.listen(silentPort, '127.0.0.1', resolve));
+
+    withCustomChatHandler('openai', `http://127.0.0.1:${silentPort}`);
+
+    const gatewayPort = await getPort();
+    const app = createApp();
+    apps.push(app);
+    await app.listen({ host: '127.0.0.1', port: gatewayPort });
+
+    const response = await fetch(`http://127.0.0.1:${gatewayPort}/v1/chat/completions`, {
+      body: JSON.stringify({ messages: [{ content: 'hi', role: 'user' }], model: 'gpt-4o' }),
+      headers: {
+        authorization: 'Bearer sk-not-a-real-key',
+        'content-type': 'application/json',
+        'x-lightport-provider': 'openai',
+        'x-lightport-request-timeout': '40',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(408);
+    expect(await response.json()).toMatchObject({ error: { type: 'timeout_error' } });
+  }, 20_000);
+});

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1,4 +1,4 @@
-import { getClientAbortSignal } from '../context/clientAbort';
+import { getClientAbortSignal, runWithClientAbort } from '../context/clientAbort';
 import { GatewayError } from '../errors/GatewayError';
 import { openAiErrorResponse } from '../errors/openAiError';
 import { HEADER_KEYS, POWERED_BY, RESPONSE_HEADER_KEYS, CONTENT_TYPES } from '../globals';
@@ -237,13 +237,59 @@ async function postToProvider(
   // Check for custom request handler (e.g., bedrock AWS signing)
   const requestHandlers = providerConfig.requestHandlers;
   if (requestHandlers && requestHandlers[fn]) {
-    const customResponse = await requestHandlers[fn]!({
-      c,
-      providerOptions: providerOption,
-      requestURL: c.req.url,
-      requestHeaders,
-      requestBody,
-    });
+    // The provider call the timeout is meant to bound happens inside the custom
+    // handler, reached through externalServiceFetch like every other outbound
+    // request. That transport only picks the caller's abort signal up
+    // ambiently, so a requestTimeout set here never reached these handlers, and
+    // a file or batch call to a wedged provider hung with no deadline at all.
+    // Fold the timeout into the same ambient signal, and tell a timeout apart
+    // from a caller hangup the way the main path below does.
+    const customRequestTimeout =
+      Number(requestHeaders[HEADER_KEYS.REQUEST_TIMEOUT]) ||
+      providerOption.requestTimeout ||
+      null;
+
+    const invokeRequestHandler = () =>
+      requestHandlers[fn]!({
+        c,
+        providerOptions: providerOption,
+        requestURL: c.req.url,
+        requestHeaders,
+        requestBody,
+      });
+
+    let customResponse: Response;
+    if (customRequestTimeout) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), customRequestTimeout);
+      const clientSignal = getClientAbortSignal();
+      const combinedSignal = clientSignal
+        ? AbortSignal.any([clientSignal, controller.signal])
+        : controller.signal;
+
+      try {
+        customResponse = await runWithClientAbort(combinedSignal, invokeRequestHandler);
+      } catch (err: any) {
+        if (err.name !== 'AbortError') {
+          throw err;
+        }
+
+        // A caller hanging up is left to propagate to tryPost's guard; only a
+        // timeout the caller is still waiting on is dressed up as a 408.
+        if (getClientAbortSignal()?.aborted) {
+          throw err;
+        }
+
+        customResponse = openAiErrorResponse(
+          { message: 'Request timed out', type: 'timeout_error' },
+          408,
+        );
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    } else {
+      customResponse = await invokeRequestHandler();
+    }
 
     const { response: mappedResponse } = await responseHandler(
       c,


### PR DESCRIPTION
`postToProvider` wires `requestTimeout` (from `x-lightport-request-timeout` / `providerOption.requestTimeout`) into the outbound fetch on the main path, but the custom-request-handler branch returns before that wiring. Providers that carry a custom handler — bedrock's `uploadFile`, `retrieveFile`, `getBatchOutput`, `retrieveFileContent` — reach the backend through `externalServiceFetch`, which only picks up the caller's abort signal ambiently. A `requestTimeout` set on a file/batch call therefore never reached the handler, and a call to a wedged provider hung with no deadline.

This folds the timeout into the same ambient abort signal (`AbortSignal.any` + `runWithClientAbort`) so the handler's internal fetch is bounded, and distinguishes a timeout from a caller hangup exactly as the main path does (408 vs. propagating to `tryPost`'s 499 guard). Adds a test that hangs without the fix and returns 408 with it (full suite 802 passed, 0 regressions).

Context: this is the fix from Portkey-AI/gateway#1778, re-targeted here per @punkpeye's pointer — verified the bug survived the handler refactor.