### PR TITLE
fix: send the last line of a file as bytes, as every line before it

### DIFF
--- a/src/handlers/__tests__/streamHandlerUtils.test.ts
+++ b/src/handlers/__tests__/streamHandlerUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createLineSplitter,
   getFormdataToFormdataStreamTransformer,
   getOctetStreamToOctetStreamTransformer,
 } from '../streamHandlerUtils';
@@ -232,5 +233,45 @@ describe('batch output read in pieces', () => {
 
   it('reads rows ending in a carriage return', async () => {
     expect(await readRows(['{"a":1}\r\n{"b":2}\r\n'])).toEqual(['{"a":1}', '{"b":2}']);
+  });
+});
+
+/**
+ * Feeds the given pieces through the line splitter and answers with whatever it
+ * put out, untouched — the point here being what the pieces are made of, not
+ * only what they say.
+ */
+const splitLines = async (pieces: string[]): Promise<unknown[]> => {
+  const splitter = createLineSplitter();
+  const encoder = new TextEncoder();
+  const writer = splitter.writable.getWriter();
+
+  const written = (async () => {
+    for (const piece of pieces) await writer.write(encoder.encode(piece));
+    await writer.close();
+  })();
+
+  const lines: unknown[] = [];
+  for await (const line of splitter.readable as any) lines.push(line);
+  await written;
+
+  return lines;
+};
+
+describe('a line splitter reading a file that ends without a newline', () => {
+  it('answers the last line as bytes, as it answers every line before it', async () => {
+    // The line held back for a newline that never comes is read at the end of
+    // the stream, and went out as the string it was held as, where every line
+    // before it went out encoded. The upload reading these lines decodes each
+    // one, and a string is not something to decode: the read threw, the catch
+    // around it dropped the line, and the last row of the file never reached
+    // the provider — leaving the body short of the length the upload was
+    // signed for, with nothing said.
+    const lines = await splitLines(['{"a":1}\n{"b":2}']);
+
+    expect(lines.every((line) => line instanceof Uint8Array)).toBe(true);
+
+    const decoder = new TextDecoder();
+    expect(lines.map((line) => decoder.decode(line as Uint8Array))).toEqual(['{"a":1}', '{"b":2}']);
   });
 });

--- a/src/handlers/streamHandlerUtils.ts
+++ b/src/handlers/streamHandlerUtils.ts
@@ -288,9 +288,15 @@ export function createLineSplitter(): TransformStream {
       }
       return;
     },
+    // The last line of a file need not end in a newline, so the line held back
+    // for one goes out here — and goes out encoded, as every line before it
+    // did. Sent as the string it was held as, it reached a reader that decodes
+    // what it is given, which a string is not: the read threw, the catch around
+    // it dropped the line, and the file went to the provider a row short of the
+    // length its upload was signed for, with nothing said.
     flush(controller) {
       if (leftover.trim()) {
-        controller.enqueue(leftover.trim());
+        controller.enqueue(encoder.encode(leftover.trim()));
       }
     },
   });


### PR DESCRIPTION
`createLineSplitter` enqueues each whole line encoded, but the line held back for a newline that never arrives — the last line of a file that does not end in one — was enqueued as the string it was held as:

```ts
transform(...) { controller.enqueue(encoder.encode(line.trim())); }  // Uint8Array
flush(controller) { if (leftover.trim()) controller.enqueue(leftover.trim()); }  // string
```

The Fireworks file upload (`src/providers/fireworks-ai/uploadFile.ts`) reads these lines and decodes every chunk it is given. A string is not a `BufferSource`, so `TextDecoder.decode` throws, the `catch` around it drops the chunk, and the last row of the file never reaches the provider. The uploaded body is then a row short of the content length the pre-signed URL was signed for, and GCS rejects the upload against `x-goog-content-length-range` — with nothing said about why.

This is reachable with ordinary tenant input: a JSONL file uploaded through `POST /v1/files` with the fireworks-ai provider, whose last line has no trailing newline (the normal shape of an exported JSONL).

The flush now encodes what it sends, as the transform above it does.

A test feeds the splitter a file whose last line has no newline and checks that every line comes out as bytes and reads back whole. It fails before the change and passes after; full suite 802 passed, 0 regressions.
