### PR TITLE
fix(cerebras): forward supported chat parameters

### DIFF
--- a/src/providers/cerebras/__tests__/chatComplete.test.ts
+++ b/src/providers/cerebras/__tests__/chatComplete.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { transformUsingProviderConfig } from '../../../services/transformToProviderRequest';
+import type { Params } from '../../../types/requestBody';
+import type { ProviderConfig } from '../../types';
+import { cerebrasProviderAPIConfig } from '..';
+
+describe('Cerebras chat completions', () => {
+  it('forwards supported OpenAI-compatible parameters', () => {
+    const sent = transformUsingProviderConfig(
+      cerebrasProviderAPIConfig.chatComplete as ProviderConfig,
+      {
+        model: 'gpt-oss-120b',
+        messages: [{ role: 'user', content: 'hello' }],
+        frequency_penalty: 0.25,
+        presence_penalty: -0.5,
+        logit_bias: { '42': 1 },
+        logprobs: true,
+        parallel_tool_calls: false,
+        service_tier: 'default',
+      } as unknown as Params,
+    );
+
+    expect(sent).toMatchObject({
+      frequency_penalty: 0.25,
+      presence_penalty: -0.5,
+      logit_bias: { '42': 1 },
+      logprobs: true,
+      parallel_tool_calls: false,
+      service_tier: 'default',
+    });
+  });
+});

--- a/src/providers/cerebras/index.ts
+++ b/src/providers/cerebras/index.ts
@@ -9,18 +9,9 @@ export const cerebrasProviderAPIConfig = defineOpenAICompatibleProvider({
     chatComplete: {
       path: '/v1/chat/completions',
       defaultModel: null,
-      exclude: [
-        'frequency_penalty',
-        'logit_bias',
-        'logprobs',
-        'presence_penalty',
-        'parallel_tool_calls',
-        'service_tier',
-      ],
     },
-    // Cerebras documents the parameters its completions endpoint takes, and
-    // these are the ones it leaves out. `logprobs` is excluded from chat above
-    // and named among them here, so the two lists differ on purpose.
+    // Chat and text completions expose different parameter sets. These are the
+    // OpenAI text-completion parameters Cerebras leaves out.
     complete: {
       path: '/v1/completions',
       defaultModel: null,


### PR DESCRIPTION
## Summary

- remove stale Cerebras chat-completion exclusions for `frequency_penalty`, `logit_bias`, `logprobs`, `presence_penalty`, `parallel_tool_calls`, and `service_tier`
- add a provider request-transformation test proving the exact values reach the outgoing payload
- update the text-completions comment so it no longer claims chat `logprobs` is unsupported

## Why

The current Cerebras chat-completions API accepts these OpenAI-compatible parameters. Lightport currently removes them locally, so callers receive no error but their requested behavior is silently lost.

This carries forward the fix from [Portkey-AI/gateway#1774](https://github.com/Portkey-AI/gateway/pull/1774) after that repository directed ongoing maintenance to Lightport.

## Validation

- `pnpm exec vitest run src/providers`: 24 files and 354 tests passed
- focused Cerebras serialization test passed
- `pnpm lint`
- `pnpm exec oxfmt --check`
- type-aware Oxlint check
- `pnpm build`
- `git diff --check`

The full local test run passed 56 files and 806 tests. Twelve credential or model-dependent live integration checks returned external 404 or 500 responses across several providers, including unchanged Anthropic, Cerebras, Groq, Together AI, Fireworks AI, DeepInfra, and OpenRouter checks.