### PR TITLE
fix(empiriolabs): real ping model, and text completions with the published parameters

### DIFF
--- a/src/__tests__/provider-ping.test.ts
+++ b/src/__tests__/provider-ping.test.ts
@@ -84,10 +84,9 @@ const PROVIDERS: ProviderEntry[] = [
   },
   {
     provider: 'empiriolabs',
-    // Named from the house that made it, as this aggregator's catalogue does.
-    // Unconfirmed against a live key — nobody here has one — so the first run
-    // that does have one settles it.
-    model: 'gpt-4o-mini',
+    // Named from the house that made it, as this catalogue does. Confirmed
+    // against a live key: gpt-4o-mini is not an id EmpirioLabs serves.
+    model: 'qwen3-7-max',
     env: { EMPIRIOLABS_API_KEY: '' },
   },
   {

--- a/src/providers/empiriolabs/index.ts
+++ b/src/providers/empiriolabs/index.ts
@@ -2,22 +2,39 @@ import { EMPIRIOLABS } from '../../globals';
 import { defineOpenAICompatibleProvider } from '../open-ai-base/define';
 
 /**
- * EmpirioLabs, an aggregator serving models from some thirty houses.
+ * EmpirioLabs AI, serving text, image, audio and video models. Part of the
+ * catalogue runs on GPU infrastructure EmpirioLabs operates itself.
  *
  * No default model: its catalogue names models for the house that made them, so
  * there is no bare name to fall back to and nothing sensible to choose on a
  * caller's behalf. A request naming none is answered by EmpirioLabs itself,
  * saying which field it wanted.
  *
- * Text completions are left out. The route answers, but which parameters it
- * takes is not published, and forwarding a list assumed from the endpoint being
- * OpenAI-shaped is the guess this file exists to avoid making.
+ * Text completions take the published list and nothing wider: model, prompt,
+ * stream, temperature, max_tokens, top_p, stop, logit_bias. The remaining
+ * OpenAI completion parameters are excluded rather than assumed, since the
+ * endpoint being OpenAI-shaped is not a statement about which of them it reads.
  */
 const EmpirioLabsConfig = defineOpenAICompatibleProvider({
   name: EMPIRIOLABS,
   baseURL: 'https://api.empiriolabs.ai',
   endpoints: {
     chatComplete: { path: '/v1/chat/completions', defaultModel: null },
+    complete: {
+      path: '/v1/completions',
+      defaultModel: null,
+      exclude: [
+        'n',
+        'logprobs',
+        'echo',
+        'presence_penalty',
+        'frequency_penalty',
+        'best_of',
+        'user',
+        'seed',
+        'suffix',
+      ],
+    },
     // Most of the catalogue is generation rather than chat.
     imageGenerate: { path: '/v1/images/generations', defaultModel: null },
     embed: { path: '/v1/embeddings', defaultModel: null },


### PR DESCRIPTION
Follow-ups to the two things left open on #4.

**The ping model was a guess, and a wrong one.** The entry used `gpt-4o-mini`, which EmpirioLabs does not serve. I had a key, so this is now settled rather than assumed: `qwen3-7-max` answers, and `empiriolabs responds to a simple completion` passes against the live API.

**Text completions.** These were left out because the parameter list was not published. It is, in the OpenAPI description: `model`, `prompt`, `stream`, `temperature`, `max_tokens`, `top_p`, `stop`, `logit_bias`. So `complete` is declared with exactly that set and the remaining OpenAI completion parameters excluded, keeping the decision explicit rather than inherited from the endpoint being OpenAI-shaped. Confirmed live through the gateway: `POST /v1/completions` with `x-lightport-provider: empiriolabs` returns a `text_completion`.

**One correction to the description.** EmpirioLabs serves part of its catalogue on GPU infrastructure it operates itself, so "aggregator" undersells what the file is describing. Reworded, and the modalities named.

On the other question from #4: `/v1/responses` is native, and a request with the OpenAI Responses body returns `object: "response"`. I tried declaring it here and backed it out. `nativeResponses: true` only tells the adapter not to translate; without a `createModelResponse` config the route answers `createModelResponse is not supported by empiriolabs`, and the declare form has no field for that endpoint today. That looked like your call to make on the shared helper rather than mine to add from outside, so it is left alone here. Happy to do it if you want it.

Build, oxlint and the ping suite are green.
